### PR TITLE
Feat/improved theming capabilities

### DIFF
--- a/app/react-native/src/preview/components/OnDeviceUI/index.tsx
+++ b/app/react-native/src/preview/components/OnDeviceUI/index.tsx
@@ -45,6 +45,7 @@ interface OnDeviceUIProps {
   isUIHidden?: boolean;
   shouldDisableKeyboardAvoidingView?: boolean;
   keyboardAvoidingViewVerticalOffset?: number;
+  renderFooter?: () => JSX.Element;
 }
 
 interface OnDeviceUIState {
@@ -121,6 +122,7 @@ export default class OnDeviceUI extends PureComponent<OnDeviceUIProps, OnDeviceU
       isUIHidden,
       shouldDisableKeyboardAvoidingView,
       keyboardAvoidingViewVerticalOffset,
+      renderFooter,
     } = this.props;
 
     const { tabOpen, slideBetweenAnimation, previewWidth, previewHeight } = this.state;
@@ -169,6 +171,7 @@ export default class OnDeviceUI extends PureComponent<OnDeviceUIProps, OnDeviceU
             onChangeTab={this.handleToggleTab}
             initialUiVisible={!isUIHidden}
           />
+          {renderFooter ? renderFooter() : null}
         </KeyboardAvoidingView>
       </SafeAreaView>
     );

--- a/app/react-native/src/preview/index.tsx
+++ b/app/react-native/src/preview/index.tsx
@@ -42,6 +42,10 @@ export interface StorybookRootProps {
    * Controllable themes.
    */
   theme?: typeof theme;
+  /**
+   * Footer component below the Navigation bar.
+   */
+  renderFooter?: () => JSX.Element;
 }
 
 export default class Preview {
@@ -160,6 +164,7 @@ More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react
                 tabOpen={params.tabOpen}
                 shouldDisableKeyboardAvoidingView={params.shouldDisableKeyboardAvoidingView}
                 keyboardAvoidingViewVerticalOffset={params.keyboardAvoidingViewVerticalOffset}
+                renderFooter={this.props.renderFooter}
               />
             </ThemeProvider>
           );

--- a/app/react-native/src/preview/index.tsx
+++ b/app/react-native/src/preview/index.tsx
@@ -37,6 +37,13 @@ export type Params = {
   keyboardAvoidingViewVerticalOffset: number;
 } & { theme: typeof theme };
 
+export interface StorybookRootProps {
+  /**
+   * Controllable themes.
+   */
+  theme?: typeof theme;
+}
+
 export default class Preview {
   _clientApi: ClientApi;
 
@@ -138,11 +145,11 @@ More info: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#react
 
     addons.loadAddons(this._clientApi);
 
-    const appliedTheme = { ...theme, ...params.theme };
-
     // react-native hot module loader must take in a Class - https://github.com/facebook/react-native/issues/10991
     return class StorybookRoot extends PureComponent {
       render() {
+        const appliedTheme = { ...theme, ...params.theme, ...this.props.theme };
+
         if (onDeviceUI) {
           return (
             <ThemeProvider theme={appliedTheme}>


### PR DESCRIPTION
Issue: 
- Theme setup is strictly a one-time affair at the `getStorybookUI` method. There is no ability for the parent to change the value of theme if the end user chooses to do so.
- A `<Switch>` could be placed at the bottom (like a footer) of the resulting `<StorybookUIRoot>` to control the current theme without jumping into any of the "stories", but in doing so, when the end user brings up the keyboard, the "footer" used to allocate space for `<Switch>` is hidden from the Storybook's `<KeyboardAwareView>` because it's not a nested child of it.

## What I did
Add more parameters to the `<StorybookRoot>` wrapper to serve the use cases needed.

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/native?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
